### PR TITLE
Remove The "./target/release" Path

### DIFF
--- a/oreminer.sh
+++ b/oreminer.sh
@@ -14,7 +14,7 @@ KEY=${2:-$DEFAULT_KEY}
 FEE=${3:-$DEFAULT_FEE}
 THREADS=${4:-$DEFAULT_THREADS}
 
-COMMAND="./target/release/ore --rpc ${RPC_URL} --keypair ${KEY} --priority-fee ${FEE} mine --threads ${THREADS}"
+COMMAND="ore --rpc ${RPC_URL} --keypair ${KEY} --priority-fee ${FEE} mine --threads ${THREADS}"
 
 while true; do
   echo "Starting the process..."


### PR DESCRIPTION
It will solve [./target/release/ore: No such file or directory #3](https://github.com/0xrsydn/ore-miner/issues/3).
People who are new to computer will confused this error. So when we install cargo and export cargo correctly, we don't need ./target/release path to execute ore command. :)